### PR TITLE
Fix Node Install for RPM Packages

### DIFF
--- a/.github/actions/build-rpm-package/Dockerfile
+++ b/.github/actions/build-rpm-package/Dockerfile
@@ -11,12 +11,10 @@ RUN npm install && \
 FROM fedora:latest
 
 RUN yum install -y rpm-build rpmdevtools gcc rpm-sign pinentry && \
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash && \
-    export NVM_DIR="$HOME/.nvm" && \
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
-    nvm install 20.9.0
+    sudo yum install https://rpm.nodesource.com/pub_20.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y && \
+    sudo yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1
 
 COPY --from=builder /app/dist /app/dist
 COPY --from=builder /app/node_modules /app/node_modules
 
-ENTRYPOINT [ "/bin/bash", "-c", "$HOME/.nvm/versions/node/v20.9.0/bin/node /app/dist/index.js" ]
+ENTRYPOINT [ "node", "/app/dist/index.js" ]

--- a/.github/actions/build-rpm-package/src/index.ts
+++ b/.github/actions/build-rpm-package/src/index.ts
@@ -86,8 +86,6 @@ const buildPackage = async () => {
   debug('Initializing rpmbuild tree...');
   await exec('rpmdev-setuptree');
 
-  await exec('ls', ['-la']);
-
   const specFile = getInput('spec_file');
   const targetSpecFile = `${rpmBuildTmp}/SPECS/${basename(specFile)}`;
 


### PR DESCRIPTION
**Related Issue(s)**: N/A

**Change Type**: Bug

**Description**
<!-- Add a description of the changes, including (as applicable) expected behavior and known changes in behavior, especially breaking changes. -->
Switches to installing Node using nodesource instead of nvm.  This should fix issues with running node in GitHub Actions, which isn't replicable locally.