### PR TITLE
Improve Ability to Write dotenv Files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "griffin-cli",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "griffin-cli",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ssm": "^3.449.0",
@@ -19,7 +19,6 @@
         "@oclif/plugin-warn-if-update-available": "^3.0.2",
         "csv-stringify": "^6.4.4",
         "dotenv": "^16.3.1",
-        "envfile": "^6.18.0",
         "yaml": "^2.3.4"
       },
       "bin": {
@@ -4667,20 +4666,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/envfile": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/envfile/-/envfile-6.18.0.tgz",
-      "integrity": "sha512-IsYv64dtlNXTm4huvCBpbXsdZQurYUju9WoYCkSj+SDYpO3v4/dq346QsCnNZ3JcnWw0G3E6+saVkVtmPw98Gg==",
-      "bin": {
-        "envfile": "bin.cjs"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/err-code": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@oclif/plugin-warn-if-update-available": "^3.0.2",
     "csv-stringify": "^6.4.4",
     "dotenv": "^16.3.1",
-    "envfile": "^6.18.0",
     "yaml": "^2.3.4"
   },
   "devDependencies": {

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -2,11 +2,11 @@ import { writeFile } from 'fs/promises';
 
 import { Flags } from '@oclif/core';
 import * as csv from 'csv-stringify/sync';
-import * as envfile from 'envfile';
 import * as yaml from 'yaml';
 
 import BaseCommand from '../base-command';
 import { UnsupportedOptionsError } from '../errors';
+import EnvFile from '../utils/envfile';
 import getEnvVars from '../utils/get-env-vars';
 
 export enum ExportOutputFormat {
@@ -49,7 +49,7 @@ export default class Export extends BaseCommand<typeof Export> {
       }
 
       case ExportOutputFormat.DOTENV: {
-        return this.print(envfile.stringify(envVars));
+        return this.print(EnvFile.stringify(envVars));
       }
 
       case ExportOutputFormat.YAML: {

--- a/src/utils/envfile.ts
+++ b/src/utils/envfile.ts
@@ -1,0 +1,41 @@
+import normalizeEnvVarName from './normalize-env-var-name';
+
+export default class EnvFile {
+  private static newlinePattern = /[^\\]\n/;
+
+  private static specialCharacterPattern = /[#'"]/;
+
+  static stringify(data: Record<string, string | boolean | number | undefined | null>): string {
+    return Object.keys(data).reduce((acc, key) => {
+      if (data[key] === undefined) {
+        return acc;
+      }
+
+      const normalizedKey = normalizeEnvVarName(key);
+
+      if (data[key] === null) {
+        return `${acc}${normalizedKey}=\n`;
+      }
+
+      let value = data[key];
+
+      if (typeof value === 'string') {
+        if (this.newlinePattern.test(value) || this.specialCharacterPattern.test(value)) {
+          let quote = '"';
+
+          if (value.includes('"')) {
+            // If the value contains both double and single quotes, not much we can do. Some dotenv
+            // libraries support backticks, but that doesn't appear to be standard. If a value
+            // contains special characters not considered here, the user should consider base64
+            // encoding the value.
+            quote = '\'';
+          }
+
+          value = `${quote}${value}${quote}`;
+        }
+      }
+
+      return `${acc}${normalizedKey}=${value}\n`;
+    }, '');
+  }
+}

--- a/test/integration/ssm.test.ts
+++ b/test/integration/ssm.test.ts
@@ -1,5 +1,4 @@
 import { stdin } from 'mock-stdin';
-import * as envfile from 'envfile';
 
 import test from '../helpers/register';
 import { randomUUID } from 'crypto';
@@ -11,6 +10,7 @@ import { readFile, unlink, writeFile } from 'fs/promises';
 import addParam from '../helpers/add-param';
 import { ParameterType } from '@aws-sdk/client-ssm';
 import { ConfigFile, Source } from '../../src/config';
+import EnvFile from '../../src/utils/envfile';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -92,7 +92,7 @@ describe('SSM', () => {
           BOOL: 'true',
           NUMBER: '42',
         }))
-        .do(async (ctx) => writeFile(ctx.filename, envfile.stringify(ctx.params)));
+        .do(async (ctx) => writeFile(ctx.filename, EnvFile.stringify(ctx.params)));
 
       dotEnvImportTest
         .commandWithContext((ctx) => ['ssm:import', '--env', 'test', '--from-dotenv', ctx.filename, '--prefix', ctx.prefix])

--- a/test/utils/envfile.test.ts
+++ b/test/utils/envfile.test.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@oclif/test';
+
+import EnvFile from '../../src/utils/envfile';
+
+describe('EnvFile', () => {
+  describe('stringify', () => {
+    test.it('should convert a JSON object into dotenv format', () => {
+      expect(EnvFile.stringify({
+        str: 'a nice string',
+        num: 42,
+        bool: true,
+        something: `!@$%&*()_-+=[]{};:,./<>?`,
+        url: 'https://www.google.com/?q=recursion',
+      })).to.equal(`STR=a nice string
+NUM=42
+BOOL=true
+SOMETHING=!@$%&*()_-+=[]{};:,./<>?
+URL=https://www.google.com/?q=recursion
+`);
+    });
+
+    test.it('should omit fields set to undefined', () => {
+      expect(EnvFile.stringify({
+        first: 'first',
+        und: undefined,
+        second: 'second',
+      })).to.equal(`FIRST=first
+SECOND=second
+`);
+    });
+
+    test.it('should leave fields set to null empty', () => {
+      expect(EnvFile.stringify({
+        none: null,
+        one: 1,
+      })).to.equal(`NONE=
+ONE=1
+`);
+    });
+
+    test.it('should wrap strings with newlines in quotes', () => {
+      expect(EnvFile.stringify({
+        multiline: `line1
+line2
+line3`
+      })).to.equal(`MULTILINE="line1
+line2
+line3"
+`)
+    });
+
+    test.it('should not wrap strings with escaped newlines in quotes', () => {
+      expect(EnvFile.stringify({
+        escapedMultiline: 'line1\\nline2\\nline3',
+      })).to.equal(`ESCAPEDMULTILINE=line1\\nline2\\nline3
+`);
+    });
+
+    test.it('should wrap strings with a comment delimiter in quotes', () => {
+      const json = {
+        commentedString: 'a string with a # in it',
+      };
+
+      expect(EnvFile.stringify(json)).to.equal(`COMMENTEDSTRING="${json.commentedString}"
+`);
+    });
+
+    test.it('should use single quotes if the string contains double quotes', () => {
+      expect(EnvFile.stringify({
+        quotes: '"""""',
+      })).to.equal(`QUOTES='"""""'
+`);
+    });
+  });
+});


### PR DESCRIPTION
**Related Issue(s)**: N/A

**Change Type**: Feature

**Description**
<!-- Add a description of the changes, including (as applicable) expected behavior and known changes in behavior, especially breaking changes. -->
Enhances the support of griffin to write valid dotenv files.  This new writer takes into consideration

- `undefined`
- `null`
- strings with special characters (`\n`, `#`, `"`)
- keys that have not been normalized