### PR TITLE
feat!: Use yaml for `griffin-config`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ oclif.manifest.json
 .secrets
 act-tmp/
 .griffin-config.*.json
+.griffin-config.*.yaml
 .env
 tsconfig.tsbuildinfo
 coverage/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ without having to coordinate updating your config.
   - [dotenv](#dotenv)
   - [SSM](#ssm)
 - [🚏 Roadmap](#-roadmap)
+- [⬆️ Migrating JSON-based configuration](#⬆️-migrating-json-based-configuration)
 - [📖 Commands](#-commands)
   - [`griffin autocomplete [SHELL]`](#griffin-autocomplete-shell)
   - [`griffin exec COMMAND [ARGS]`](#griffin-exec-command-args)
@@ -333,6 +334,58 @@ Griffin is growing!  We're always looking for contributors and maintainers to he
   - Azure
 
 As Griffin continues to grow, we may also refactor into more of a plugin-based architecture so you only have to install what you need.
+
+# ⬆️ Migrating JSON-based configuration
+Older versions of Griffin used `JSON`-based configuration.  We've since changed the standard format to `YAML`.  Migrating this configration is fairly straightforward;  simply follow the steps below
+
+1. install the `yaml` package for python
+```sh
+pip install pyyaml 
+```
+2. Create a file named `migrate_griffin_config.py` in the root of your repository and mark it as executable
+```sh
+touch migrate_griffin_config.py
+chmod +x migrate_griffin_config.py
+```
+
+```python
+#!/usr/bin/env python
+
+import subprocess
+import yaml
+import json
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+
+def migrate(json_path: Path):
+    with json_path.open() as f:
+        json_config = json.load(f)
+
+    yaml_path = json_path.with_suffix(".yaml")
+    with yaml_path.open("w") as f:
+        yaml.dump(json_config, f)
+
+
+if __name__ == "__main__":
+    environments = HERE.glob("griffin_config.*.json")
+    for env in environments:
+        migrate(env)
+
+        # Remove the old json config
+        subprocess.run(["git", "rm", env])
+```
+
+3. run the script:
+```sh
+python migrate_griffin_config.py
+```
+
+4. (optional) remove the script
+```sh
+rm migrate_griffin_config.py
+```
 
 # 📖 Commands
 <!-- commands -->

--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ FLAGS
   -l, --latest           read the latest version
   -n, --name=<value>     (required) the name of the parameter
   -q, --quiet            print only the parameter value
-  -v, --version=<value>  the version of the parameter to read, defaults to the version in your .griffon-config.json file
+  -v, --version=<value>  the version of the parameter to read, defaults to the version in your .griffin-config.json file
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --cwd=<value>      the directory where griffin's config file is located, both relative and absolute paths are

--- a/src/commands/ssm/read.ts
+++ b/src/commands/ssm/read.ts
@@ -25,7 +25,7 @@ export default class SSMRead extends SSMBaseCommand<typeof SSMRead> {
     }),
     version: Flags.string({
       char: 'v',
-      description: 'the version of the parameter to read, defaults to the version in your .griffon-config.json file',
+      description: 'the version of the parameter to read, defaults to the version in your .griffon-config.yaml file',
       exclusive: ['latest'],
     }),
     latest: Flags.boolean({

--- a/src/commands/ssm/read.ts
+++ b/src/commands/ssm/read.ts
@@ -25,7 +25,7 @@ export default class SSMRead extends SSMBaseCommand<typeof SSMRead> {
     }),
     version: Flags.string({
       char: 'v',
-      description: 'the version of the parameter to read, defaults to the version in your .griffon-config.yaml file',
+      description: 'the version of the parameter to read, defaults to the version in your .griffin-config.yaml file',
       exclusive: ['latest'],
     }),
     latest: Flags.boolean({

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -3,6 +3,8 @@ import {
 } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
+import yaml from 'yaml';
+
 import ParamConfig from './param-config';
 import Source from './source';
 import SourceConfig from './source-config';
@@ -46,9 +48,8 @@ export default class ConfigFile {
     try {
       const filename = this.getFileName(env);
       const filepath = cwd ? resolve(process.cwd(), cwd, filename) : filename;
-      const data = await readFile(filepath);
-
-      return JSON.parse(data.toString());
+      const data = await readFile(filepath, 'utf8');
+      return yaml.parse(data);
     } catch (error) {
       if (error instanceof Error && (error as FileSystemError).code === 'ENOENT') {
         return {};
@@ -59,7 +60,7 @@ export default class ConfigFile {
   }
 
   private static getFileName(env: string): string {
-    return `.griffin-config.${env}.json`;
+    return `.griffin-config.${env}.yaml`;
   }
 
   getParamConfig(source: Source, id: string): ParamConfig | undefined {
@@ -90,8 +91,7 @@ export default class ConfigFile {
       // Make sure the directory exists.
       await mkdir(dirname(filepath), { recursive: true });
     }
-
-    await writeFile(filepath, JSON.stringify(this.config, undefined, 2));
+    await writeFile(filepath, yaml.stringify(this.config));
 
     await this.reload();
   }

--- a/test/config/config-file.test.ts
+++ b/test/config/config-file.test.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@oclif/test';
 import mock from 'mock-fs';
 
+import yaml from 'yaml'
+
 import { ConfigFile, Source } from '../../src/config';
 import { randomUUID } from 'crypto';
 import { readFile } from 'fs/promises';
@@ -19,7 +21,7 @@ describe('ConfigFile', () => {
 
       configFileTest
         .do((ctx) => mock({
-          [`.griffin-config.${ctx.env}.json`]: '',
+          [`.griffin-config.${ctx.env}.yaml`]: '',
         }))
         .do((ctx) => expect(ConfigFile.doesExist(ctx.env)).to.eventually.equal(true));
     });
@@ -29,7 +31,7 @@ describe('ConfigFile', () => {
         .add('source', Source.SSM)
         .add('id', 'id')
         .do((ctx) => mock({
-          [`.griffin-config.${ctx.env}.json`]: JSON.stringify({
+          [`.griffin-config.${ctx.env}.yaml`]: yaml.stringify({
             [ctx.source]: {
               [ctx.id]: {},
             },
@@ -53,7 +55,7 @@ describe('ConfigFile', () => {
         .add('source', Source.SSM)
         .add('id', () => randomUUID())
         .do((ctx) => mock({
-          [`./${ctx.cwd}/.griffin-config.${ctx.env}.json`]: JSON.stringify({
+          [`./${ctx.cwd}/.griffin-config.${ctx.env}.yaml`]: yaml.stringify({
             [ctx.source]: {
               [ctx.id]: {},
             },
@@ -71,7 +73,7 @@ describe('ConfigFile', () => {
         .add('source', Source.SSM)
         .add('id', () => randomUUID())
         .do((ctx) => mock({
-          [`${ctx.cwd}/.griffin-config.${ctx.env}.json`]: JSON.stringify({
+          [`${ctx.cwd}/.griffin-config.${ctx.env}.yaml`]: yaml.stringify({
             [ctx.source]: {
               [ctx.id]: {},
             },
@@ -99,7 +101,7 @@ describe('ConfigFile', () => {
         },
       }))
       .do((ctx) => mock({
-        [`.griffin-config.${ctx.env}.json`]: JSON.stringify(ctx.configFileData),
+        [`.griffin-config.${ctx.env}.yaml`]: yaml.stringify(ctx.configFileData),
       }))
       .add('config', (ctx) => ConfigFile.loadConfig(ctx.env));
 
@@ -182,7 +184,7 @@ describe('ConfigFile', () => {
     describe('save', () => {
       configInstanceTest
         .do((ctx) => ctx.config.save())
-        .do(async (ctx) => expect((await readFile(`.griffin-config.${ctx.env}.json`)).toString()).to.equal(JSON.stringify(ctx.configFileData, undefined, 2)))
+        .do(async (ctx) => expect((await readFile(`.griffin-config.${ctx.env}.yaml`)).toString()).to.equal(yaml.stringify(ctx.configFileData, undefined, 2)))
         .it('should save to a file');
     });
   });

--- a/test/helpers/reset-config.ts
+++ b/test/helpers/reset-config.ts
@@ -4,7 +4,7 @@ export default async () => {
   const files = await readdir('.');
 
   await Promise.all(files
-    .filter((file) => /\.griffin-config\..+\.json/.test(file))
+    .filter((file) => /\.griffin-config\..+\.yaml/.test(file))
     .map((file) => unlink(`./${file}`))
   );
 };

--- a/test/integration/ssm.test.ts
+++ b/test/integration/ssm.test.ts
@@ -95,7 +95,7 @@ describe('SSM', () => {
       const dirStats = await stat(resolve(process.cwd(), ctx.cwd));
       expect(dirStats.isDirectory()).to.equal(true);
 
-      const fileStats = await stat(resolve(process.cwd(), ctx.cwd, `.griffin-config.${ctx.env}.json`));
+      const fileStats = await stat(resolve(process.cwd(), ctx.cwd, `.griffin-config.${ctx.env}.yaml`));
       expect(fileStats.isFile()).to.equal(true);
 
       const output = (await readFile('./test-script-output.txt')).toString();
@@ -116,7 +116,7 @@ describe('SSM', () => {
       const dirStats = await stat(resolve(process.cwd(), ctx.cwd));
       expect(dirStats.isDirectory()).to.equal(true);
 
-      const fileStats = await stat(resolve(process.cwd(), ctx.cwd, `.griffin-config.${ctx.env}.json`));
+      const fileStats = await stat(resolve(process.cwd(), ctx.cwd, `.griffin-config.${ctx.env}.yaml`));
       expect(fileStats.isFile()).to.equal(true);
 
       const output = (await readFile('./test-script-output.txt')).toString();


### PR DESCRIPTION
**Related Issue(s)**:  N/A

**Change Type**: Feature

**Description**
`yaml` is the de-facto configuration format of our day.  It's generally considered [more readable](https://stackoverflow.com/questions/1726802/what-is-the-difference-between-yaml-and-json) than other serialization formats, among other things.

Given that this tool is designed to help operators keep configuration "in sync" with code changes, it would be very useful to make eyeballing those changes easier to spot.